### PR TITLE
Use wildcard for architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Simple but useful macroses for logging. Allow use printf() with Serial 
 paragraph=
 category=Other
 url=http://www.openbionics.com
-architectures=all
+architectures=*
 includes=logger.h


### PR DESCRIPTION
The previous `architectures` value of `all` is interpreted by the Arduino IDE as the library being written for an architecture named "all". This causes the example sketch to be moved to **File > Examples > INCOMPATIBLE** and also the following warning is displayed when any sketch that includes the library is compiled:
```
WARNING: library arduino-logger claims to run on (all) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```